### PR TITLE
fix: support multi feature processes for GS projector

### DIFF
--- a/src/main/clojure/pdok/util.clj
+++ b/src/main/clojure/pdok/util.clj
@@ -15,6 +15,11 @@
 (defn uuid<= [uuid-a uuid-b]
   (<= 0 (.compare ^UUIDComparator uuid-comparator uuid-a uuid-b) 0))
 
+(defmacro checked [f on-error-check]
+  "Executes f and on errors will check if error-check is ok. If not throws original error."
+  `(try ~f
+        (catch Exception e#
+         (when (not ~on-error-check) (throw e#)))))
 
 (defmacro with-bench
   "Evaluates expr, followed by bench-out (setting t to time it took in ms) and returning expr"

--- a/src/test/clojure/pdok/featured/util_test.clj
+++ b/src/test/clojure/pdok/featured/util_test.clj
@@ -1,0 +1,13 @@
+(ns pdok.featured.util-test
+  (:require [clojure.test :refer :all]
+            [pdok.util :refer :all]))
+
+(defn return [val]
+  val)
+
+(-> checked-ok
+    (deftest
+      (is (= nil (checked (/ 1 0) (return true))))))
+
+(deftest checked-real-error
+  (is (thrown? ArithmeticException (checked (/ 1 0) (return false)))))


### PR DESCRIPTION
On add table and add column exceptions, check if table or column is already there. If so, ignore exception