### PR TITLE
fix: close childs together with parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  [log4j/log4j "1.2.17"]
                  [org.slf4j/slf4j-api "1.7.12"]
                  [org.slf4j/slf4j-log4j12 "1.7.12"]
-                 [postgresql "9.3-1102.jdbc41"]
+                 [org.postgresql/postgresql "9.4.1209.jre7"]
                  [prismatic/schema "0.4.3"]
                  [ring/ring-defaults "0.1.5"]
                  [ring/ring-json "0.3.1"]

--- a/src/main/clojure/pdok/featured/data_fixes.clj
+++ b/src/main/clojure/pdok/featured/data_fixes.clj
@@ -1,0 +1,34 @@
+(ns pdok.featured.data-fixes
+  (:require [pdok.featured.persistence :as pers]
+            [pdok.featured.processor :as proc]
+            [clojure.tools.logging :as log]
+            [clojure.core.async :as a]))
+
+(defn close-childs [{:keys [persistence] :as processor} perform?]
+  (let [collections (map :name
+                         (filter #(not (:parent-collection %))
+                                 (pers/collections persistence)))]
+    (doseq [collection collections]
+      (when (seq (pers/child-collections persistence collection))
+        (log/info "Fixing:" collection)
+        (let [n-closed (atom 0)
+              stream-ids (pers/streams persistence collection)
+              parts (a/pipe stream-ids (a/chan 1 (partition-all 10000)))]
+          (loop [part (a/<!! parts)
+                 i 1]
+            (when (seq part)
+              (pers/prepare persistence (map (fn [id] {:collection collection :id id}) part))
+              (let [could-be-closed (filter #(= :close (pers/last-action persistence collection %)) part)
+                    close-actions (map (fn [id] {:action            :close-childs
+                                                 :parent-collection collection
+                                                 :parent-id         id
+                                                 :validity          (pers/current-validity persistence collection id)})
+                                       could-be-closed)]
+                (swap! n-closed #(+ % (count could-be-closed)))
+                (when perform?
+                  (dorun (proc/consume* processor close-actions))))
+              (pers/flush persistence)
+              (log/info "Total closed:" (:n-processed @(:statistics processor)))
+              (log/info "Processed:" (* i 10000) "- Total closed parents:" @n-closed)
+              (when (or perform? (> 5 i)) (recur (a/<!! parts) (inc i)))))
+          (log/info "Completed:" collection "- Total closed" @n-closed "parents"))))))

--- a/src/main/clojure/pdok/featured/processor.clj
+++ b/src/main/clojure/pdok/featured/processor.clj
@@ -427,9 +427,9 @@
     (update-in processor [:projectors] conj initialized-projector)))
 
 (defn create
-  ([dataset persistence] (create persistence dataset []))
-  ([dataset persistence projectors] (apply create {} dataset persistence projectors))
-  ([options dataset persistence & projectors]
+  ([dataset persistence] (create dataset persistence []))
+  ([dataset persistence projectors] (create {} dataset persistence projectors))
+  ([options dataset persistence projectors]
    {:pre [(map? options) (string? dataset)]}
    (let [initialized-persistence (pers/init persistence dataset)
          initialized-projectors (doall (map #(proj/init % dataset (pers/collections initialized-persistence))

--- a/src/main/clojure/pdok/util.clj
+++ b/src/main/clojure/pdok/util.clj
@@ -21,6 +21,12 @@
         (catch Exception e#
          (when (not ~on-error-check) (throw e#)))))
 
+(defn partitioned [f n coll]
+  "executes f with max n elemenents from coll"
+  (let [parts (partition-all n coll)
+        results (map f parts)]
+    (mapcat identity results)))
+
 (defmacro with-bench
   "Evaluates expr, followed by bench-out (setting t to time it took in ms) and returning expr"
   [t bench-out & expr]

--- a/src/test/clojure/pdok/featured/regression_test.clj
+++ b/src/test/clojure/pdok/featured/regression_test.clj
@@ -331,7 +331,8 @@
   (test-timeline->extract {:n-extracts 3
                            :n-valid-to 2}
                           (:extracts results))
-  (test-geoserver 1))
+  (test-geoserver "col-1" 1)
+  (test-geoserver "col-1$nested" 1))
 
 (defpermutatedtest new_double_nested-delete-new_double_nested-change_double_nested "new_double_nested-delete-new_double_nested-change_double_nested" results
   (is (= (+ 3 3 3 5) (:n-processed (:stats results))))
@@ -405,3 +406,17 @@
                                             :n-valid-to 0}
                                            (:extracts results))
                    (test-geoserver 1))
+
+(defpermutatedtest new-nested_close-parent "new_nested-close_parent" results
+                   (is (= 4 (:n-processed (:stats results))))
+                   (is (= 0 (:n-errored (:stats results))))
+                   (test-persistence {:events 2 :features 1})
+                   (test-persistence "col-1$nested" {:events 2 :features 1})
+                   (test-timeline {:timeline {:n 1}
+                                   :timeline-changelog {:n-new 1 :n-change 1 :n-close 2}}
+                                  (:changelog-counts results))
+                   (test-timeline->extract {:n-extracts 1
+                                            :n-valid-to 1}
+                                           (:extracts results))
+                   (test-geoserver "col-1" 0)
+                   (test-geoserver "col-1$nested" 0))

--- a/src/test/clojure/pdok/featured/util_test.clj
+++ b/src/test/clojure/pdok/featured/util_test.clj
@@ -11,3 +11,15 @@
 
 (deftest checked-real-error
   (is (thrown? ArithmeticException (checked (/ 1 0) (return false)))))
+
+(deftest partitioned-test
+  (let [n-calls (atom 0)
+        ids (range 100)
+        f (fn [id] [id (inc id)])
+        mapper (fn [coll] (swap! n-calls inc) (map f coll))
+        normal (mapper ids)
+        parted (partitioned mapper 10 ids)]
+    (is (= [0 1] (first normal)))
+    (is (= (take 2 normal) '([0 1] [1 2])))
+    (is (= normal parted))
+    (is (= 11 @n-calls))))

--- a/src/test/resources/regression/new_nested-close_parent.json
+++ b/src/test/resources/regression/new_nested-close_parent.json
@@ -1,0 +1,17 @@
+{"_check_validity_on_delete" : false,
+ "Features": [
+     {"_action":"new",
+      "_id":"id-a",
+      "_validity":"2016-01-11T14:00:00.000",
+      "_collection":"col-1",
+      "attra":"1",
+      "nested": { "info": "a",
+          "_geometry": {"type":"gml","gml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?><gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:pos>154742.108 464096.362</gml:pos></gml:Point>"}},
+      "_geometry":{"type":"gml","gml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?><gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:pos>154742.108 464096.362</gml:pos></gml:Point>"}},
+     {"_action":"close",
+      "_id":"id-a",
+      "_current_validity": "2016-01-11T14:00:00.000",
+      "_validity":"2016-01-12T14:00:00.000",
+      "_collection":"col-1"
+      }
+ ]}


### PR DESCRIPTION
I think there is no usecase to not do this. If the child is manually closed afterwards, this will result in an error.