### PR TITLE
PDOK-3502 Top-level exception handling instead of silently failing

### DIFF
--- a/src/main/clojure/pdok/featured/geoserver.clj
+++ b/src/main/clojure/pdok/featured/geoserver.clj
@@ -4,11 +4,11 @@
             [pdok.util :refer [checked]]
             [pdok.featured.feature :as f :refer [as-jts]]
             [pdok.postgres :as pg]
-            [clojure.core.cache :as cache]
             [clojure.java.jdbc :as j]
             [clojure.string :as str]
             [clojure.tools.logging :as log])
-  (:import (clojure.lang PersistentQueue)))
+  (:import (clojure.lang PersistentQueue)
+           (java.sql SQLException)))
 
 (defn- remove-keys [map keys]
   (apply dissoc map keys))
@@ -73,8 +73,9 @@
   (let [table collection]
     (try
       (pg/add-column db dataset table attribute-name attribute-value)
-      (catch java.sql.SQLException e
-        (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))))))
+      (catch SQLException e
+        (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))
+        (throw e)))))
 
 (defn- feature-to-sparse-record [proj-fn feature all-fields-constructor import-nil-geometry?]
   ;; could use a valid-geometry? check?! For now not, as-jts return nil if invalid (for gml)
@@ -147,8 +148,9 @@
                                   all-attributes)
                    sql (gs-insert-sql dataset collection fields)]
                (j/execute! db (cons sql records) :multi? true :transaction? (:transaction? db)))))))
-     (catch java.sql.SQLException e
-       (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))))))
+     (catch SQLException e
+       (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))
+       (throw e)))))
 
 
 (defn- gs-update-sql [schema table columns]
@@ -161,8 +163,9 @@
     (let [table collection
           sql (gs-update-sql dataset table (map name columns))]
       (j/execute! db (cons sql update-vals) :multi? true :transaction? (:transaction? db)))
-    (catch java.sql.SQLException e
-      (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e)))))
+    (catch SQLException e
+      (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))
+      (throw e))))
 
 (defn- gs-update-feature [{:keys [db dataset] :as gs} proj-fn features]
     (let [selector (juxt :collection)
@@ -191,8 +194,9 @@
               sql (gs-delete-sql dataset table)
               ids (map #(vector (:id %1) (:current-version %1)) collection-features)]
           (j/execute! db (cons sql ids) :multi? true :transaction? (:transaction? db)))))
-    (catch java.sql.SQLException e
-      (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e)))))
+    (catch SQLException e
+      (log/with-logs ['pdok.featured.projectors :error :error] (j/print-sql-exception-chain e))
+      (throw e))))
 
 (defn- make-flush-all [proj-fn cache insert-batch update-batch delete-batch no-insert]
   "Used for flushing all batches, so entry order is alway new change close"


### PR DESCRIPTION
Currently, featured catches SQL exceptions at the lowest level, logs them and forgets about them. The application calling the REST endpoint has no idea something went wrong.

This change removes the low-level try-catch blocks, instead making sure that every top-level entry point has one try-catch block "to rule them all" and to return the correct HTTP status codes.

Where new information about exceptions is returned, this does not break the data format datamanagement expects.