### PR TITLE
PDOK-3730 Fix double versions bug in timeline and extracts

### DIFF
--- a/src/main/clojure/pdok/featured/extracts.clj
+++ b/src/main/clojure/pdok/featured/extracts.clj
@@ -96,7 +96,7 @@
 (defn- jdbc-delete-versions [db table versions]
   "([version valid_from][version valid_from] ... )"
   (let [versions-only (map #(take 1 %) (filter (fn [[_ valid-from]] (not valid-from)) versions))
-        with-valid-from (map (fn [[ov nv]] [ov nv ov nv]) (filter (fn [[_ valid-from]] valid-from) versions))]
+        with-valid-from (map (fn [[ov vf]] [ov vf ov vf]) (filter (fn [[_ valid-from]] valid-from) versions))]
     (when (seq versions-only)
       (let [query (str "DELETE FROM " extract-schema "." table
                        " WHERE version = ?")]

--- a/src/main/clojure/pdok/featured/extracts.clj
+++ b/src/main/clojure/pdok/featured/extracts.clj
@@ -96,7 +96,7 @@
 (defn- jdbc-delete-versions [db table versions]
   "([version valid_from][version valid_from] ... )"
   (let [versions-only (map #(take 1 %) (filter (fn [[_ valid-from]] (not valid-from)) versions))
-        with-valid-from (map #(vector (nth % 0) (nth % 1) (nth % 0) (nth % 1)) (filter (fn [[_ valid-from]] valid-from) versions))]
+        with-valid-from (map (fn [[ov nv]] [ov nv ov nv]) (filter (fn [[_ valid-from]] valid-from) versions))]
     (when (seq versions-only)
       (let [query (str "DELETE FROM " extract-schema "." table
                        " WHERE version = ?")]

--- a/src/main/clojure/pdok/featured/timeline.clj
+++ b/src/main/clojure/pdok/featured/timeline.clj
@@ -114,10 +114,8 @@
 (defn changed-features [{:keys [dataset] :as timeline} collection]
    (let [query (str "SELECT cl.collection, cl.feature_id, cl.old_version, cl.version, cl.action, cl.valid_from, tl.feature
  FROM " (qualified-changelog dataset) " AS cl
- LEFT JOIN
-(SELECT feature_id, version, valid_from, feature  FROM "
- (qualified-timeline dataset collection)
-") as tl ON cl.version = tl.version AND cl.valid_from = tl.valid_from
+ LEFT JOIN " (qualified-timeline dataset collection) " AS tl
+ ON cl.version = tl.version AND cl.valid_from = tl.valid_from
  ORDER BY cl.id ASC")]
      (query-with-results-on-channel timeline query upgrade-changelog)))
 
@@ -253,7 +251,8 @@
 (defn- sync-version [acc feature]
   (-> acc
       (update-in [:_all_versions] (fnil conj '()) (:version feature))
-      (assoc :_version (:version feature))))
+      (update-in [:_all_versions] distinct)
+      (assoc :_version (first (:_all_versions acc)))))
 
 (defn- sync-valid-to [acc feature]
   (let [changed (assoc acc :_valid_to (:validity feature))]
@@ -309,7 +308,8 @@ VALUES (?, ?, ?, ?, ?, ?)"))
 
 (defn- delete-version-with-valid-from-sql [dataset collection]
   (str "DELETE FROM " (qualified-timeline dataset collection)
-       " WHERE version = ? AND valid_from = ?"))
+       " WHERE version = ? AND valid_from = ? AND id IN (SELECT id FROM " (qualified-timeline dataset collection)
+       " WHERE version = ? AND valid_from = ? ORDER BY id ASC LIMIT 1)"))
 
 (defn- delete-version [{:keys [db dataset]} records]
   "([collection version valid-from] ... )"
@@ -317,7 +317,7 @@ VALUES (?, ?, ?, ?, ?, ?)"))
   (let [per-collection (group-by first records)]
     (doseq [[collection collection-records] per-collection]
       (let [versions-only (map #(vector (nth % 1)) (filter (fn [[_ _ valid-from]] (not valid-from)) collection-records))
-            with-valid-from (map #(drop 1 %) (filter (fn [[_ _ valid-from]] valid-from) collection-records))]
+            with-valid-from (map #(vector (nth % 1) (nth % 2) (nth % 1) (nth % 2)) (filter (fn [[_ _ valid-from]] valid-from) collection-records))]
         (when (seq versions-only)
           (try
             (j/execute! db (cons (delete-version-sql dataset collection) versions-only) :multi? true :transaction? (:transaction? db))
@@ -441,7 +441,7 @@ VALUES (?, ?, ?, ?, ?, ?)"))
                   ;; reset valid-to for new-current.
                   (cache-batched-new (reset-valid-to (sync-valid-from new-current feature)))
                   (batched-append-changelog [(:_collection new-current)
-                                             (:_id new-current) (:_version current) (:_version new-current)
+                                             (:_id new-current) (:_version current) (:_version current)
                                              (:_valid_from current) :close])
                   (batched-append-changelog [(:_collection new-current)
                                              (:_id new-current) nil

--- a/src/test/clojure/pdok/featured/regression_test.clj
+++ b/src/test/clojure/pdok/featured/regression_test.clj
@@ -170,6 +170,7 @@
 (defn- test-timeline->extract [expected extracts]
   ;  (println "EXTRACTS\n" (clojure.string/join "\n" (map (fn [e] (into [] (take 2 e))) @extracts)))
   (is (= (:n-extracts expected) (count @extracts)))
+  (is (= (:n-extracts expected) (count (distinct (map first @extracts))))) ; extracts should have distinct versions
   (is (= (:n-valid-to expected) (count (filter #((complement nil?) (nth % 2)) @extracts)))))
 
 (defn- query-geoserver [table]

--- a/src/test/clojure/pdok/featured/regression_test.clj
+++ b/src/test/clojure/pdok/featured/regression_test.clj
@@ -43,16 +43,18 @@
     [meta features]))
 
 (defn- inserted-features [extracts dataset extract-type collection features]
-  (doseq [f features]
-    (let [record (vector (:_version f) (:_valid_from f) (:_valid_to f) f)]
-      (swap! extracts conj record))))
+  (let [new-extracts (map #(vector (:_version %) (:_valid_from %) (:_valid_to %) %) features)]
+    (swap! extracts concat new-extracts)))
+
+(defn- remove-first [pred coll]
+  (keep-indexed #(if (not= %1 (.indexOf coll (first (filter pred coll)))) %2) coll))
 
 (defn- remove-extract-record [extracts record-info]
   (let [[version valid-from] record-info]
     (if valid-from
-      (into [] (remove #(and (= version  (nth %1 0))
-                             (= valid-from (nth %1 1))) extracts))
-      (into [] (remove #(= version (nth % 0)) extracts)))))
+      (remove-first #(and (= version (nth %1 0))
+                          (= valid-from (nth %1 1))) extracts)
+      (remove #(= version (nth % 0)) extracts))))
 
 (defn- deleted-versions [extracts dataset collection extract-type records]
     (doseq [record records]


### PR DESCRIPTION
De bug werd veroorzaakt door het feit dat een "change" (met één versie-UUID) wordt vervangen door een "close" en een "new" en die hetzelfde versienummer kregen. Omdat zowel de close als de new tot een entry in de timeline en de extracten leidt, kwam daar een dubbel versienummer te staan.

De oplossing leek heel simpel: de close moet de versie-UUID krijgen van de versie die hij afsluit, niet van de nieuwe versie. Echter doet featured eerst alle inserts en dan alle deletes in batch, dus de delete die bedoeld was om de oude versie zonder einddatum te verwijderen, verwijderde ook de net ingevoegde oude versie met einddatum. Daarom heb ik niet alleen het versienummer dat de close krijgt aangepast, maar ook gezorgd dat er per delete maximaal één entry verwijderd wordt, namelijk de oudste. Daarmee werkt alles weer zoals verwacht.

Tot slot heb ik de regressietest uitgebreid met een check op dubbele versienummers. Daarmee slaagt featured met deze fix voor de regressietest, maar zonder niet meer.