### PR TITLE
PDOK-4811 Use one database transaction per call (API or CLI)

### DIFF
--- a/src/main/clojure/pdok/featured/api.clj
+++ b/src/main/clojure/pdok/featured/api.clj
@@ -90,7 +90,7 @@
   (let [dataset (:dataset request)
         filestore (config/filestore)
         persistence (if (:no-state request) (persistence/make-no-state) (config/persistence))
-        projectors (if (:no-timeline request) [] [(config/timeline persistence filestore)])
+        projectors (if (:no-timeline request) [] [(config/timeline filestore)])
         processor (processor/create dataset persistence projectors)
         zipped? (= (:format request) "zip")
         [file err] (download-file (:file request) zipped?)]

--- a/src/main/clojure/pdok/featured/config.clj
+++ b/src/main/clojure/pdok/featured/config.clj
@@ -61,14 +61,9 @@
 
 (defn timeline
   ([]
-   (timeline (persistence)))
-  ([persistence]
-   (timeline persistence (filestore (str (System/getProperty "java.io.tmpdir") "/featured"))))
-  ([persistence filestore]
-   (timeline/create-chunked {:chunk-size  (read-string (or (env :processor-batch-size) "10000"))
-                             :db-config   processor-db
-                             :persistence persistence}
-                            filestore)))
+   (timeline (filestore (str (System/getProperty "java.io.tmpdir") "/featured"))))
+  ([filestore]
+   (timeline/create-chunked {:chunk-size (read-string (or (env :processor-batch-size) "10000"))} filestore)))
 
 (defn create-workers [factory-f]
   (let [n-workers (read-string (or (env :n-workers) "2"))]

--- a/src/main/clojure/pdok/featured/config.clj
+++ b/src/main/clojure/pdok/featured/config.clj
@@ -35,7 +35,8 @@
          (load-props "plp.properties")))
 
 (def processor-db {:subprotocol "postgresql"
-                   :subname (or (env :processor-database-url) "//localhost:5432/pdok")
+                   :subname (str (or (env :processor-database-url) "//localhost:5432/pdok")
+                                 "?ApplicationName=pdok-featured")
                    :user (or (env :processor-database-user) "postgres")
                    :password (or (env :processor-database-password) "postgres")
                    :transaction? true})

--- a/src/main/clojure/pdok/featured/core.clj
+++ b/src/main/clojure/pdok/featured/core.clj
@@ -19,7 +19,7 @@
   (let [changelog-dir (if (:changelog-dir meta) (:changelog-dir meta) (str (System/getProperty "user.dir") "/changelog"))
         filestore (config/filestore changelog-dir)
         persistence (if no-state (pers/make-no-state) (config/persistence))
-        projectors (if no-timeline [] [(config/timeline persistence filestore)])
+        projectors (if no-timeline [] [(config/timeline filestore)])
         processor (processor/create meta dataset persistence projectors)]
     processor))
 

--- a/src/main/clojure/pdok/featured/processor.clj
+++ b/src/main/clojure/pdok/featured/processor.clj
@@ -289,8 +289,8 @@
         _ (when statistics (log/info @statistics))]
     info))
 
-(defn add-projector [processor projector]
-  (let [initialized-projector (proj/init projector (:dataset processor) (pers/collections (:persistence processor)))]
+(defn add-projector [processor projector tx]
+  (let [initialized-projector (proj/init projector tx (:dataset processor) (pers/collections (:persistence processor)))]
     (update-in processor [:projectors] conj initialized-projector)))
 
 (defn create
@@ -299,7 +299,8 @@
   ([options dataset persistence projectors]
    {:pre [(map? options) (string? dataset)]}
    (let [initialized-persistence (pers/init persistence dataset)
-         initialized-projectors (doall (map #(proj/init % dataset (pers/collections initialized-persistence))
+         tx (:tx initialized-persistence)
+         initialized-projectors (doall (map #(proj/init % tx dataset (pers/collections initialized-persistence))
                                             (clojure.core/flatten projectors)))
          batch-size (or (config/env :processor-batch-size) 10000)]
      (merge {:dataset dataset

--- a/src/main/clojure/pdok/featured/projectors.clj
+++ b/src/main/clojure/pdok/featured/projectors.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [flush]))
 
 (defprotocol Projector
-  (init [persistence for-dataset current-collections])
+  (init [persistence tx for-dataset current-collections])
   (new-collection [persistence collection])
   (flush [persistence])
   (new-feature [persistence feature])

--- a/src/main/clojure/pdok/postgres.clj
+++ b/src/main/clojure/pdok/postgres.clj
@@ -3,11 +3,15 @@
             [clj-time [coerce :as tc]]
             [clojure.tools.logging :as log]
             [pdok.transit :as transit]
-            [pdok.featured.feature :as f])
-  (:import [com.vividsolutions.jts.io WKTWriter]
-           [java.util Calendar TimeZone]
-           [org.joda.time DateTimeZone LocalDate LocalDateTime]
-           (java.sql Types)))
+            [pdok.featured.feature :as f]
+            [clojure.string :as str])
+  (:import (clojure.lang IMeta IPersistentList IPersistentMap IPersistentSet IPersistentVector Keyword PersistentVector)
+           (com.vividsolutions.jts.geom Geometry)
+           (com.vividsolutions.jts.io WKTWriter)
+           (java.sql Array Connection Date PreparedStatement SQLException Timestamp Types)
+           (java.util Calendar TimeZone UUID)
+           (org.joda.time DateTime DateTimeZone LocalDate LocalDateTime)
+           (pdok.featured GeometryAttribute NilAttribute)))
 
 (def wkt-writer (WKTWriter.))
 
@@ -18,30 +22,30 @@
 (def serverTimeZone (DateTimeZone/getDefault))
 
 (extend-protocol j/ISQLValue
-  org.joda.time.DateTime
+  DateTime
   (sql-value [v] (tc/to-sql-time v))
-  org.joda.time.LocalDateTime
+  LocalDateTime
   (sql-value [v] (tc/to-sql-time v))
-  org.joda.time.LocalDate
+  LocalDate
   (sql-value [v] (tc/to-sql-date v))
-  pdok.featured.GeometryAttribute
+  GeometryAttribute
   (sql-value [v] (-> v f/as-jts j/sql-value))
-  com.vividsolutions.jts.geom.Geometry
+  Geometry
   (sql-value [v] (str "SRID=" (.getSRID v) ";" (.write ^WKTWriter wkt-writer v)))
-  clojure.lang.Keyword
+  Keyword
   (sql-value [v] (name v))
-  clojure.lang.IPersistentMap
+  IPersistentMap
   (sql-value [v] (transit/to-json v)))
 
 (deftype NilType [clazz]
   j/ISQLValue
   (sql-value [_] nil)
-  clojure.lang.IMeta
+  IMeta
   (meta [_] {:type clazz}))
 
 (declare clj-to-pg-type)
 
-(defn write-vector [v ^java.sql.PreparedStatement s ^long i]
+(defn write-vector [v ^PreparedStatement s ^long i]
   (if (empty? v)
     (.setObject s i nil Types/ARRAY)
     (let [con (.getConnection s)
@@ -50,82 +54,82 @@
       (.setObject s i postgres-array Types/ARRAY))))
 
 (extend-protocol j/ISQLParameter
-  pdok.featured.NilAttribute
-  (set-parameter [^pdok.featured.NilAttribute v ^java.sql.PreparedStatement s ^long i]
+  NilAttribute
+  (set-parameter [^NilAttribute v ^PreparedStatement s ^long i]
     (j/set-parameter (NilType. (.-clazz v)) s i))
-  org.joda.time.LocalDateTime
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  LocalDateTime
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setTimestamp s i (j/sql-value v) utcCal))
-  org.joda.time.LocalDate
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  LocalDate
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setDate s i (j/sql-value v) utcCal))
-  java.util.UUID
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  UUID
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setObject s i (j/sql-value v) Types/OTHER))
-  pdok.featured.GeometryAttribute
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  GeometryAttribute
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setObject s i (j/sql-value v) Types/OTHER))
-  com.vividsolutions.jts.geom.Geometry
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  Geometry
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setObject s i (j/sql-value v) Types/OTHER))
-  clojure.lang.IPersistentMap
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  IPersistentMap
+  (set-parameter [v ^PreparedStatement s ^long i]
     (.setObject s i (j/sql-value v) Types/VARCHAR))
-  clojure.lang.IPersistentVector
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  IPersistentVector
+  (set-parameter [v ^PreparedStatement s ^long i]
     (write-vector v s i))
-  clojure.lang.PersistentVector
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  PersistentVector
+  (set-parameter [v ^PreparedStatement s ^long i]
     (write-vector v s i))
-  clojure.lang.IPersistentList
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  IPersistentList
+  (set-parameter [v ^PreparedStatement s ^long i]
     (if (empty? v)
       (.setObject s i nil Types/OTHER)
       (j/set-parameter (into-array v) s i)))
-  clojure.lang.IPersistentSet
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  IPersistentSet
+  (set-parameter [v ^PreparedStatement s ^long i]
     (j/set-parameter (into [] v) s i)))
 
 (extend-protocol j/ISQLParameter
   (Class/forName "[Ljava.lang.Long;")
-   (set-parameter [v ^java.sql.PreparedStatement s ^long i]
-      (let [con (.getConnection s)
-            postgres-array (.createArrayOf con "integer" v)]
-        (.setObject s i postgres-array Types/ARRAY))))
+  (set-parameter [v ^PreparedStatement s ^long i]
+    (let [con (.getConnection s)
+          postgres-array (.createArrayOf con "integer" v)]
+      (.setObject s i postgres-array Types/ARRAY))))
 
 (extend-protocol j/ISQLParameter
   (Class/forName "[Ljava.lang.Integer;")
-   (set-parameter [v ^java.sql.PreparedStatement s ^long i]
-      (let [con (.getConnection s)
-            postgres-array (.createArrayOf con "integer" v)]
-        (.setObject s i postgres-array Types/ARRAY))))
+  (set-parameter [v ^PreparedStatement s ^long i]
+    (let [con (.getConnection s)
+          postgres-array (.createArrayOf con "integer" v)]
+      (.setObject s i postgres-array Types/ARRAY))))
 
 (extend-protocol j/ISQLParameter
   (Class/forName "[Ljava.util.UUID;")
-   (set-parameter [v ^java.sql.PreparedStatement s ^long i]
-      (let [con (.getConnection s)
-            postgres-array (.createArrayOf con "uuid" v)]
-        (.setObject s i postgres-array Types/ARRAY))))
+  (set-parameter [v ^PreparedStatement s ^long i]
+    (let [con (.getConnection s)
+          postgres-array (.createArrayOf con "uuid" v)]
+      (.setObject s i postgres-array Types/ARRAY))))
 
 (extend-protocol j/ISQLParameter
   (Class/forName "[Ljava.lang.String;")
-  (set-parameter [v ^java.sql.PreparedStatement s ^long i]
+  (set-parameter [v ^PreparedStatement s ^long i]
     (let [con (.getConnection s)
           postgres-array (.createArrayOf con "text" v)]
       (.setObject s i postgres-array Types/ARRAY))))
 
 (extend-protocol j/IResultSetReadColumn
-  java.sql.Date
-  (result-set-read-column [v _ _] (LocalDate. ^java.sql.Date v ^DateTimeZone serverTimeZone))
-  java.sql.Timestamp
-  (result-set-read-column [v _ _] (LocalDateTime. ^java.sql.Timestamp v ^DateTimeZone serverTimeZone))
-  java.sql.Array
+  Date
+  (result-set-read-column [v _ _]
+    (LocalDate. ^Date v ^DateTimeZone serverTimeZone))
+  Timestamp
+  (result-set-read-column [v _ _]
+    (LocalDateTime. ^Timestamp v ^DateTimeZone serverTimeZone))
+  Array
   (result-set-read-column [v _ _]
     (into [] (.getArray v))))
 
 (def geometry-type "geometry")
-
-(declare clj-to-pg-type)
 
 (defn vector->pg-type [v]
   (let [e (first v)]
@@ -135,31 +139,80 @@
   (let [clj-type (type clj-value)]
     (condp = clj-type
       nil "text"
-      pdok.featured.NilAttribute (clj-to-pg-type (NilType. (.-clazz clj-value)))
-      clojure.lang.Keyword "text"
-      clojure.lang.IPersistentMap "text"
-      clojure.lang.IPersistentVector (vector->pg-type clj-value)
-      clojure.lang.PersistentVector (vector->pg-type clj-value)
-      org.joda.time.DateTime "timestamp with time zone"
-      org.joda.time.LocalDateTime "timestamp without time zone"
-      org.joda.time.LocalDate "date"
-      java.lang.Integer "integer"
-      java.lang.Double "double precision"
-      java.lang.Boolean "boolean"
-      java.util.UUID "uuid"
-      pdok.featured.GeometryAttribute geometry-type
+      NilAttribute (clj-to-pg-type (NilType. (.-clazz clj-value)))
+      Keyword "text"
+      IPersistentMap "text"
+      IPersistentVector (vector->pg-type clj-value)
+      PersistentVector (vector->pg-type clj-value)
+      DateTime "timestamp with time zone"
+      LocalDateTime "timestamp without time zone"
+      LocalDate "date"
+      Integer "integer"
+      Double "double precision"
+      Boolean "boolean"
+      UUID "uuid"
+      GeometryAttribute geometry-type
       "text")))
 
 (def quoted (j/quoted \"))
 
+(defn sql-identifier [s]
+  (j/quoted \" (name s)))
+
+(defn qualified-table [schema table]
+  (str (sql-identifier schema) "." (sql-identifier table)))
+
 (defn begin-transaction [db]
   (let [connection (j/get-connection db)
         _ (.setAutoCommit connection false)]
-    (j/add-connection db connection)))
+    {:connection connection}))
 
 (defn commit-transaction [tx]
   (with-open [connection (j/get-connection tx)]
     (.commit connection)))
+
+(defn execute-batch-query
+  ([tx ^String query]
+   (execute-batch-query tx query []))
+  ([tx ^String query batch]
+   (with-open [stmt (let [^Connection c (:connection tx)] (.prepareStatement c query))]
+     (doseq [values batch]
+       (doseq [value (map-indexed vector values)]
+         (j/set-parameter
+           (second value)
+           ^PreparedStatement stmt
+           ^Integer (-> value first inc)))
+       (.addBatch ^PreparedStatement stmt))
+     (.executeBatch ^PreparedStatement stmt))))
+
+(defn batch-insert [tx qualified-table columns batch]
+  (let [query (str "INSERT INTO " qualified-table
+                   "(" (->> columns (map sql-identifier) (str/join ", ")) ")"
+                   " VALUES (" (->> columns (map (constantly "?")) (str/join ", ")) ")")]
+    (execute-batch-query tx query batch)))
+
+(defn batch-delete [tx qualified-table columns batch]
+  (let [query (str "DELETE FROM " qualified-table
+                   " WHERE " (->> columns (map sql-identifier) (map #(str % " = ?")) (str/join " AND ")))]
+    (execute-batch-query tx query batch)))
+
+(defn execute-query
+  ([tx ^String query]
+   (execute-query tx query []))
+  ([tx ^String query values]
+   (with-open [stmt (let [^Connection c (:connection tx)] (.prepareStatement c query))]
+     (doseq [value (map-indexed vector values)]
+       (j/set-parameter
+         (second value)
+         ^PreparedStatement stmt
+         ^Integer (-> value first inc)))
+     (.execute ^PreparedStatement stmt))))
+
+(defn insert [tx qualified-table columns values]
+  (let [query (str "INSERT INTO " qualified-table
+                   "(" (->> columns (map sql-identifier) (str/join ", ")) ")"
+                   " VALUES (" (->> columns (map (constantly "?")) (str/join ", ")) ")")]
+    (execute-query tx query values)))
 
 (defn schema-exists? [tx schema]
   (let [query "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?"
@@ -167,8 +220,7 @@
     (not (nil? (first results)))))
 
 (defn create-schema [tx schema]
-  "Create schema"
-  (j/execute! tx [(str "CREATE SCHEMA " (-> schema name quoted))]))
+  (execute-query tx (str "CREATE SCHEMA " (sql-identifier schema))))
 
 (defn table-exists? [tx schema table]
   (let [query "SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?"
@@ -176,7 +228,7 @@
     (not (nil? (first results)))))
 
 (defn create-table [tx schema table & fields]
-  (j/execute! tx [(apply j/create-table-ddl (str (-> schema name quoted) "." (-> table name quoted)) fields)]))
+  (execute-query tx (apply j/create-table-ddl (qualified-table schema table) fields)))
 
 (defn- remove-underscores [name]
   (if (= (first name) \_)
@@ -189,10 +241,10 @@
         index-name (str (name table) "_" (clojure.string/join "_" (map remove-underscores column-names))
                         (or (index-type {:gist "_sidx"}) "_idx"))]
     (try
-      (j/execute! tx [(str "CREATE INDEX " (quoted index-name)
-                           " ON " (-> schema name quoted) "." (-> table name quoted)
-                           " USING " (name index-type) " (" quoted-columns ")")])
-      (catch java.sql.SQLException e
+      (execute-query tx (str "CREATE INDEX " (quoted index-name)
+                             " ON " (qualified-table schema table)
+                             " USING " (name index-type) " (" quoted-columns ")"))
+      (catch SQLException e
         (log/with-logs ['pdok.postgres :error :error] (j/print-sql-exception-chain e))
         (throw e)))))
 
@@ -202,7 +254,7 @@
 (defn kv->clause [[k v]]
   (if v
     (str (name k) " = '" (clojure.string/replace v #"'" "''") "'")
-    (str (name k) " is null")))
+    (str (name k) " IS NULL")))
 
 (defn map->where-clause
   ([clauses] (clojure.string/join " AND " (map kv->clause clauses)))
@@ -211,12 +263,12 @@
 (defn configure-auto-vacuum [tx schema table vacuum-scale-factor vacuum-threshold analyze-scale-factor]
   (try
     (do
-      (j/execute! tx [(str "ALTER TABLE " (-> schema name quoted) "." (-> table name quoted)
-                           " SET (autovacuum_vacuum_scale_factor = " vacuum-scale-factor ")")])
-      (j/execute! tx [(str "ALTER TABLE " (-> schema name quoted) "." (-> table name quoted)
-                           " SET (autovacuum_vacuum_threshold = " vacuum-threshold ")")])
-      (j/execute! tx [(str "ALTER TABLE " (-> schema name quoted) "." (-> table name quoted)
-                           " SET (autovacuum_analyze_scale_factor = " analyze-scale-factor ")")]))
-    (catch java.sql.SQLException e
+      (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
+                             " SET (autovacuum_vacuum_scale_factor = " vacuum-scale-factor ")"))
+      (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
+                             " SET (autovacuum_vacuum_threshold = " vacuum-threshold ")"))
+      (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
+                             " SET (autovacuum_analyze_scale_factor = " analyze-scale-factor ")")))
+    (catch SQLException e
       (log/with-logs ['pdok.postgres :error :error] (j/print-sql-exception-chain e))
       (throw e))))

--- a/src/test/clojure/pdok/featured/performance_test.clj
+++ b/src/test/clojure/pdok/featured/performance_test.clj
@@ -42,7 +42,7 @@
      #'dc/*timeline-schema-prefix* :featured_performance}
     (let [[meta features] (jr/features-from-stream (clojure.java.io/reader feature-stream))
           persistence (config/persistence)
-          timeline (config/timeline persistence)
+          timeline (config/timeline)
           processor (processor/create
                       (merge {:check-validity-on-delete false} cfg)
                       "performance-set" persistence [timeline])]

--- a/src/test/clojure/pdok/featured/processor_test.clj
+++ b/src/test/clojure/pdok/featured/processor_test.clj
@@ -34,7 +34,7 @@
 
 (defrecord MockedProjector [features-n changes-n collections]
   proj/Projector
-  (init [this for-dataset current-collections]
+  (init [this tx for-dataset current-collections]
     (vreset! collections current-collections)
     (-> this (assoc :initialized true)))
   (new-collection [this collection] (vswap! collections conj {:name collection}))

--- a/src/test/clojure/pdok/featured/regression_test.clj
+++ b/src/test/clojure/pdok/featured/regression_test.clj
@@ -72,7 +72,7 @@
                     (map (fn [features]
                            (let [persistence (config/persistence)
                                  filestore (config/filestore changelog-dir)
-                                 timeline (config/timeline persistence filestore)
+                                 timeline (config/timeline filestore)
                                  processor (processor/create meta "regression-set" persistence [timeline])]
                              (dorun (processor/consume processor features))
                              (:statistics (processor/shutdown processor))))
@@ -83,7 +83,7 @@
   (println "  Replaying")
   (let [persistence (config/persistence)
         filestore (config/filestore changelog-dir)
-        timeline (config/timeline persistence filestore)
+        timeline (config/timeline filestore)
         processor (processor/create {} "regression-set" persistence [timeline])]
     (processor/replay processor 1000 nil)
     {:stats (:statistics (processor/shutdown processor)) :extracts nil}))


### PR DESCRIPTION
Now that the GeoServer and extracts code has been removed, interaction with the database takes place from two classes: `Persistence` and `Timeline`. A new instance of these is created for every call (either from the API or from the CLI). Therefore, the easiest way to implement transactionality on a per-call basis was to start a transaction on initializing a new persistence and to commit it on closing the persistence. This transaction is passed around to all functions that use the database. Furthermore, `clojure.java.jdbc/execute!` was replaced by a custom implementation because this was the only way to prevent automatic commits.