### PR TITLE
Fix "prepare caches" performance issue

### DIFF
--- a/src/main/clojure/pdok/featured/persistence.clj
+++ b/src/main/clojure/pdok/featured/persistence.clj
@@ -62,7 +62,7 @@ If n nil => no limit, if collections nil => all collections")
                                     [:collection "varchar(255)"]
                                     [:feature_id "varchar(255)"])
                    (pg/create-index tx dc/*persistence-schema* dc/*persistence-features* :collection :feature_id)
-                   (pg/configure-auto-vacuum tx dc/*persistence-schema* dc/*persistence-features* 0 10000 0))
+                   (pg/configure-auto-vacuum tx dc/*persistence-schema* dc/*persistence-features* 0 10000 0 5000))
                (pg/table-exists? tx dc/*persistence-schema* dc/*persistence-features*)))
 
     (when-not (pg/table-exists? tx dc/*persistence-schema* dc/*persistence-feature-stream*)
@@ -76,7 +76,7 @@ If n nil => no limit, if collections nil => all collections")
                                     [:validity "timestamp without time zone"]
                                     [:attributes "text"])
                    (pg/create-index tx dc/*persistence-schema* dc/*persistence-feature-stream* :collection :feature_id)
-                   (pg/configure-auto-vacuum tx dc/*persistence-schema* dc/*persistence-feature-stream* 0 10000 0))
+                   (pg/configure-auto-vacuum tx dc/*persistence-schema* dc/*persistence-feature-stream* 0 10000 0 5000))
                (pg/table-exists? tx dc/*persistence-schema* dc/*persistence-feature-stream*)))
 
     (when-not (pg/table-exists? tx dc/*persistence-schema* dc/*persistence-collections*)

--- a/src/main/clojure/pdok/featured/timeline.clj
+++ b/src/main/clojure/pdok/featured/timeline.clj
@@ -43,7 +43,8 @@
                                       [:feature "text"]
                                       [:tiles "integer[]"])
                      (pg/create-index tx dc/*timeline-schema* table-name :feature_id)
-                     (pg/create-index tx dc/*timeline-schema* table-name :version))
+                     (pg/create-index tx dc/*timeline-schema* table-name :version)
+                     (pg/configure-auto-vacuum tx dc/*timeline-schema* table-name 0 10000 0 5000))
                  (pg/table-exists? tx dc/*timeline-schema* table-name))))))
 
 (defn current [tx dataset collection]

--- a/src/main/clojure/pdok/postgres.clj
+++ b/src/main/clojure/pdok/postgres.clj
@@ -257,7 +257,7 @@
   ([clauses] (clojure.string/join " AND " (map kv->clause clauses)))
   ([clauses table] (clojure.string/join " AND " (map #(str table "." (kv->clause %)) clauses))))
 
-(defn configure-auto-vacuum [tx schema table vacuum-scale-factor vacuum-threshold analyze-scale-factor]
+(defn configure-auto-vacuum [tx schema table vacuum-scale-factor vacuum-threshold analyze-scale-factor analyze-threshold]
   (try
     (do
       (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
@@ -265,7 +265,9 @@
       (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
                              " SET (autovacuum_vacuum_threshold = " vacuum-threshold ")"))
       (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
-                             " SET (autovacuum_analyze_scale_factor = " analyze-scale-factor ")")))
+                             " SET (autovacuum_analyze_scale_factor = " analyze-scale-factor ")"))
+      (execute-query tx (str "ALTER TABLE " (qualified-table schema table)
+                             " SET (autovacuum_analyze_threshold = " analyze-threshold ")")))
     (catch SQLException e
       (log/with-logs ['pdok.postgres :error :error] (j/print-sql-exception-chain e))
       (throw e))))

--- a/src/test/clojure/pdok/featured/performance_test.clj
+++ b/src/test/clojure/pdok/featured/performance_test.clj
@@ -15,11 +15,6 @@
   (j/execute! test-db ["DROP SCHEMA IF EXISTS \"featured_performance_performance-set\" CASCADE"])
   (j/execute! test-db ["DROP SCHEMA IF EXISTS \"performance-set\" CASCADE"]))
 
-(defn vacuum-tables []
-  (j/execute! test-db ["VACUUM ANALYZE \"featured_performance_performance-set\".feature"] :transaction? false)
-  (j/execute! test-db ["VACUUM ANALYZE \"featured_performance_performance-set\".feature_stream"] :transaction? false)
-  (j/execute! test-db ["VACUUM ANALYZE \"featured_performance_performance-set\".timeline_col1"] :transaction? false))
-
 (defn generate-new-features [ids difficult?]
   (with-bindings {#'generator/*difficult-geometry?* difficult?}
     (generator/random-json-feature-stream "performance-set" "col1" (count ids)
@@ -52,8 +47,7 @@
                       (merge {:check-validity-on-delete false} cfg)
                       "performance-set" persistence [timeline])]
       (dorun (processor/consume processor features))
-      (let [statistics (processor/shutdown processor)
-            _ (vacuum-tables)]
+      (let [statistics (processor/shutdown processor)]
       (:statistics statistics)))))
 
 (deftest double-file-test


### PR DESCRIPTION
Making Featured transactional introduced a performance issue in "prepare caches", because "auto analyze" does not run until the transaction is committed. Without the correct statistics, all features of a `collection` were fetched and only then filtered on `id`. It turned out that filtering by `collection` in "prepare caches" is actually completely redundant. Removing that filter (and only filtering by `id`) fixes this problem: the optimal query plan is chosen from the very beginning.